### PR TITLE
Realistic Lighting Overhaul SSE #8

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -113,7 +113,49 @@ plugins:
       - Graphics
       - Invent
       - Names
-      - Stats
+      - Stats      
+  - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+      - 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+      - 'Realistic Lighting Overhaul - Dawnguard Interiors.esp'
+      - 'Realistic Lighting Overhaul - Dungeons.esp'
+      - 'Realistic Lighting Overhaul - Weathers.esp'
+      - 'Realistic Lighting Overhaul - Dawnguard Weathers.esp'
+  - name: 'Realistic Lighting Overhaul - Dawnguard Weathers.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+      - 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+      - 'Realistic Lighting Overhaul - Dawnguard Interiors.esp'
+      - 'Realistic Lighting Overhaul - Dungeons.esp'
+      - 'Realistic Lighting Overhaul - Weathers.esp'
+  - name: 'Realistic Lighting Overhaul - Weathers.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+      - 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+      - 'Realistic Lighting Overhaul - Dawnguard Interiors.esp'
+      - 'Realistic Lighting Overhaul - Dungeons.esp'
+  - name: 'Realistic Lighting Overhaul - Dungeons.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+      - 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+      - 'Realistic Lighting Overhaul - Dawnguard Interiors.esp'
+  - name: 'Realistic Lighting Overhaul - Dawnguard Interiors.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+      - 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+  - name: 'Realistic Lighting Overhaul - Major City Exteriors.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
+      - 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+  - name: 'Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp'
+    after:
+      - 'Realistic Lighting Overhaul - Major City Interiors.esp'
   - name: 'BetterQuestObjectives.esp'
     tag:
       - NoMerge

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -113,7 +113,7 @@ plugins:
       - Graphics
       - Invent
       - Names
-      - Stats      
+      - Stats
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
     after:
       - 'Realistic Lighting Overhaul - Major City Interiors.esp'


### PR DESCRIPTION
pStyl3 commented 3 days ago • edited
Realistic Lighting Overhaul SSE

We should ensure that the plugins from this mod will load in the following order (as laid out here):

Realistic Lighting Overhaul - Major City Interiors.esp
Realistic Lighting Overhaul - Minor Cities and Town Interiors.esp
Realistic Lighting Overhaul - Major City Exteriors.esp
Realistic Lighting Overhaul - Dawnguard Interiors.esp
Realistic Lighting Overhaul - Dungeons.esp
Realistic Lighting Overhaul - Weathers.esp
Realistic Lighting Overhaul - Dawnguard Weathers.esp
RLO - Major City Exteriors - No Guard Torches.esp